### PR TITLE
Rename the crate to 'litetx'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ltx"
+name = "litetx"
 version = "0.1.0"
 edition = "2021"
 description = "Lite Transaction File (LTX) encoding/decoding"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -30,7 +30,7 @@ pub enum Error {
 /// # let v = Vec::new();
 /// # let mut r = &mut &v[..];
 /// #
-/// let (mut dec, header) = ltx::Decoder::new(r).expect("decoder");
+/// let (mut dec, header) = litetx::Decoder::new(r).expect("decoder");
 ///
 /// let mut buf = vec![0; header.page_size.into_inner() as usize];
 /// while let Some(page_num) = dec.decode_page(&mut buf).expect("decode_page") {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -42,21 +42,21 @@ impl From<Error> for io::Error {
 /// # Example
 /// ```
 /// # use std::time::SystemTime;
-/// # use ltx::PageChecksum;
+/// # use litetx::PageChecksum;
 /// # let mut w = Vec::new();
 /// # let page = vec![0; 4096];
 /// #
-/// let mut enc = ltx::Encoder::new(&mut w, &ltx::Header{
-///     flags: ltx::HeaderFlags::empty(),
-///     page_size: ltx::PageSize::new(4096).unwrap(),
-///     commit: ltx::PageNum::new(1).unwrap(),
-///     min_txid: ltx::TXID::ONE,
-///     max_txid: ltx::TXID::ONE,
+/// let mut enc = litetx::Encoder::new(&mut w, &litetx::Header{
+///     flags: litetx::HeaderFlags::empty(),
+///     page_size: litetx::PageSize::new(4096).unwrap(),
+///     commit: litetx::PageNum::new(1).unwrap(),
+///     min_txid: litetx::TXID::ONE,
+///     max_txid: litetx::TXID::ONE,
 ///     timestamp: SystemTime::now(),
 ///     pre_apply_checksum: None,
 /// }).expect("encoder");
 ///
-/// let page_num = ltx::PageNum::new(1).unwrap();
+/// let page_num = litetx::PageNum::new(1).unwrap();
 /// enc.encode_page(page_num, &page).expect("encode_page");
 ///
 /// enc.finish(page.page_checksum(page_num)).expect("finish");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use litetx as ltx;
 use rand::prelude::*;
 use rusqlite::{Connection, OpenFlags};
 use std::{

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -1,4 +1,4 @@
-use ltx::PageChecksum;
+use litetx::{self as ltx, PageChecksum};
 use std::{
     ffi::OsString,
     fs,
@@ -11,13 +11,13 @@ mod common;
 #[test]
 #[cfg_attr(not(feature = "compat"), ignore)]
 fn encode_uncompressed() {
-    encode(ltx::HeaderFlags::empty());
+    encode(litetx::HeaderFlags::empty());
 }
 
 #[test]
 #[cfg_attr(not(feature = "compat"), ignore)]
 fn encode_compressed() {
-    encode(ltx::HeaderFlags::COMPRESS_LZ4);
+    encode(litetx::HeaderFlags::COMPRESS_LZ4);
 }
 
 #[cfg_attr(not(feature = "compat"), ignore)]


### PR DESCRIPTION
'ltx' is already taken on crates.io.
